### PR TITLE
Change allowIframe by allowedTags

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,15 @@ GitDown::parseAndCache($markdown, function ($parse) {
 });
 ```
 
-## Allowing Iframes
+## Allowing Dangerous Tags
 By default, GitHub sanitizes HTML tags it deems "unsafe" like `<iframe>`s. However, it's common to embed video or audio into your markdown with `<iframe>`s.
 
-GitDown can intelligently preserve your iframes by setting the `allowIframes` config option in `config/gitdown.php` to `true`.
+GitDown can intelligently preserve your tags by filling the `allowedTags` config array option in `config/gitdown.php` with the tags you want to prevent to be parsed.
 
 ```php
-"allowIframes" => true,
+"allowedTags" => [
+    'iframe'
+],
 ```
 
 ## Non-Laravel Usage
@@ -93,7 +95,7 @@ You can set a GitHub Personal Access Token by passing it into the `GitDown`'s co
 $gitDown = new GitDown\GitDown(
     $token = 'foo',
     $context = 'your/repo',
-    $allowIframes = false
+    $allowedTags = []
 );
 
 $gitDown->parse($markdown);

--- a/src/GitDownServiceProvider.php
+++ b/src/GitDownServiceProvider.php
@@ -13,7 +13,7 @@ class GitDownServiceProvider extends ServiceProvider
             return new GitDown(
                 config('gitdown.token'),
                 config('gitdown.context'),
-                config('gitdown.allowIframes')
+                config('gitdown.allowedTags')
             );
         });
     }

--- a/src/config-stub.php
+++ b/src/config-stub.php
@@ -30,15 +30,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Allow Iframes
+    | Allow Dangerous Tags
     |--------------------------------------------------------------------------
     |
     | By default, GitHub escapes any HTML tags it deems "unsafe" while parsing.
     | For example, passing in a string like "<iframe></iframe>" will output
-    | "&lt;iframe&gt;&lt;/iframe&gt;". This config will work-around this.
+    | "&lt;iframe&gt;&lt;/iframe&gt;". This config allow you to specify those
+    | tags that you want to preserve.
     |
     */
 
-    'allowIframes' => false,
+    'allowedTags' => [],
 
 ];

--- a/tests/GitDownTest.php
+++ b/tests/GitDownTest.php
@@ -49,10 +49,10 @@ EOT
     }
 
     /** @test */
-    public function parsed_html_preserves_iframes()
+    public function parsed_html_preserves_dangerous_tags()
     {
-        $parsed = (new GitDown(null, null, $allowIframes = true))->parse('<iframe></iframe>');
+        $parsed = (new GitDown(null, null, $allowedTags = ['iframe', 'script']))->parse('<iframe></iframe><script></script>');
 
-        $this->assertEquals('<p><iframe></iframe></p>', trim($parsed));
+        $this->assertEquals('<p><iframe></iframe><script></script></p>', trim($parsed));
     }
 }


### PR DESCRIPTION
And use it as an array to preserve more than one tag.

There's still one issue with this approach.

I tried marking `blockquote` as a `dangerousTag` in order to be encrypted by Gitdown, but I'm losing some classes after parsing it, so the tweet mentioned in #3 is still not loaded.

@calebporzio Any idea what can be done about it? 🤔