### PR TITLE
Updated parseAndCache() method.

### DIFF
--- a/src/GitDown.php
+++ b/src/GitDown.php
@@ -90,15 +90,17 @@ class GitDown
 
     public function parseAndCache($content, $minutes = null)
     {
-        if (is_callable($minutes)) {
-            return $minutes($this->generateParseCallback($content));
-        } elseif (is_null($minutes)) {
+        if (is_null($minutes)) {
             return cache()->rememberForever(sha1($content), function () use ($content) {
                 return $this->parse($content);
             });
         }
 
-        return cache()->remember(sha1($content), $minutes, function () use ($content) {
+        if (is_callable($minutes)) {
+            return $minutes($this->generateParseCallback($content));
+        }
+
+        return cache()->remember(sha1($content), now()->addMinutes(int $minutes), function () use ($content) {
             return $this->parse($content);
         });
     }


### PR DESCRIPTION
- Reorganized if statements to avoid else statements.
- changed default behavior of cache()->remember() statement to enforce minutes and integers, even in Laravel 5.8+. Should throw a more legible and understandable error if you try to `parseAndCache($content, 'foobar');`